### PR TITLE
Fix/istanbul test coverage

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -4,17 +4,11 @@ instrumentation:
   extensions:
     - .js
   default-excludes: true
-  excludes: ['node_modules']
-  embed-source: false
-  variable: __coverage__
-  compact: true
-  preserve-comments: false
-  complete-copy: false
-  save-baseline: false
-  baseline-file: ./coverage/coverage-baseline.json
+  excludes:
+    - src/**/*.spec.js
+    - node_modules
   include-all-sources: true
-  include-pid: false
-  es-modules: false
+  es-modules: true
 reporting:
   print: summary
   reports:
@@ -37,10 +31,6 @@ reporting:
     text: {file: null, maxCols: 0}
     text-lcov: {file: lcov.info}
     text-summary: {file: null}
-hooks:
-  hook-run-in-context: false
-  post-require-hook: null
-  handle-sigint: false
 check:
   global:
     statements: 50

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ $ npm test
 $ npm run test:watch
 ```
 
+##### Generate code coverage report
+```
+$ npm run coverage
+```
+
 Read the **[Testing guide](docs/TESTING.md)** for more information about writing tests.
 
 ## Deployment

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bundle:ios": "node ./node_modules/react-native/local-cli/cli.js bundle --platform ios --entry-file index.ios.js --bundle-output ios/PepperoniAppTemplate/main.jsbundle --dev=false --minify --verbose",
     "test": "mocha src/**/*.spec.js",
     "test:watch": "chokidar 'src/**/*.js' 'test/**/*.js' -c 'npm test'",
-    "coverage": "babel-node node_modules/isparta/bin/isparta cover --i=src/**/*.js --x=src/**/*.spec.js --x=node_modules node_modules/mocha/bin/_mocha -- src/**/*.spec.js",
+    "coverage": "rimraf coverage && istanbul cover --i=src/**/*.js _mocha -- src/**/*.spec.js",
     "check-coverage": "istanbul check-coverage"
   },
   "dependencies": {
@@ -33,6 +33,7 @@
     "lodash": "^4.11.0",
     "moment": "^2.12.0",
     "react": "15.0.2",
+    "react-dom": "15.0.2",
     "react-native": "^0.26.2",
     "react-native-gifted-spinner": "0.0.4",
     "react-native-lock": "futurice/react-native-lock#feature/customizedTheme",
@@ -56,12 +57,11 @@
     "eslint": "^2.8.0",
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-react": "^4.3.0",
-    "isparta": "^4.0.0",
-    "istanbul": "^0.4.3",
+    "istanbul": "1.0.0-alpha.2",
     "mocha": "^2.4.5",
     "react-addons-test-utils": "15.0.2",
-    "react-dom": "15.0.2",
     "react-native-mock": "^0.2.2",
+    "rimraf": "^2.5.2",
     "sinon": "^1.17.4"
   }
 }


### PR DESCRIPTION
I was too eager with the previous PR ([#16](https://github.com/futurice/pepperoni-app-kit/pull/16)). I noticed that in my own project, `isparta` didn't cover React classes at all and I couldn't get it to work correctly. In previous life I got it working, but that project used `babel@5.x` IIRC and other different dependencies. I switched to `istanbul@1.0.0-alpha.2` which fixes the issue and doesn't generate coverage statistics on files that are not even imported in tests. 

The alpha version of `istanbul` seems to be ok for generating coverage reports and checking coverage and 1.0.0 version is under development, where as the author of `isparta` has abandoned the project, based on [this comment](https://github.com/douglasduteil/isparta/issues/115#issuecomment-204180234).

Screenshot of the issue on `TabBar.js`: `render()` is tested on multiple cases, on the left is `isparta` coverage and on the right `istanbul`:
![coverage_diff](https://cloud.githubusercontent.com/assets/6649492/15471719/2953741a-2100-11e6-8473-2f702404694c.png)

Below is the full coverage of the files (`isparta` on the left, `istanbul` on the right), notice the difference in files like `redux/middleware/loggerMiddleware.js` which isn't really tested at all:
![full_coverage_diff](https://cloud.githubusercontent.com/assets/6649492/15472074/ee8b4176-2101-11e6-8237-92eb2bf50adc.png)

Apologies for premature pull requesting.