### PR TITLE
Possible solution for issue #25

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,6 @@
-pod 'Lock', '~> 1.24'
-pod 'Lock/TouchID'
-pod 'Lock/SMS'
-pod 'Lock/Email'
+target 'Kindling' do
+	pod 'Lock', '~> 1.24'
+	pod 'Lock/TouchID'
+	pod 'Lock/SMS'
+	pod 'Lock/Email'
+end


### PR DESCRIPTION
According to the CocoaPods 1.0:

> All targets have to be explicitly defined in the Podfile, and their names have to match up with the target name in Xcode.
[Source](http://blog.cocoapods.org/CocoaPods-1.0/)