### PR TITLE
Cocoapods doesn't run update by default now

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -58,8 +58,13 @@ The Auth0 login and sign up screens can be customized through the Lock extension
 
 2. Install native iOS dependencies
 
-        $ (cd ios; pod install)
+        $ cd ios
+      
+        $ pod repo update
 
+        $ pod install
+ 
+  
 3. Build the app and run the simulator:
 
         $ react-native run-ios


### PR DESCRIPTION
Running ```pod repo update``` fixes # 31 (maybe).  

I was not getting the same exact failure, but as reported, an error w/ ```pod install``` 

My error specifically was due to CocoaPods not running  ```pod repo update`` as part of the ```pod install```.

I was able to successfully start the app on iOS simulator