### PR TITLE
Fix check-coverage script

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -12,9 +12,9 @@ instrumentation:
 reporting:
   print: summary
   reports:
-    - lcov
     - text
     - html
+    - json
   dir: ./coverage
   watermarks:
     statements: [50, 80]
@@ -24,7 +24,7 @@ reporting:
   report-config:
     clover: {file: clover.xml}
     cobertura: {file: cobertura-coverage.xml}
-    json: {file: coverage-final.json}
+    json: {file: coverage.json}
     json-summary: {file: coverage-summary.json}
     lcovonly: {file: lcov.info}
     teamcity: {file: null, blockName: Code Coverage Summary}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "mocha src/**/*.spec.js",
     "test:watch": "chokidar 'src/**/*.js' 'test/**/*.js' -c 'npm test'",
     "coverage": "rimraf coverage && istanbul cover --i=src/**/*.js _mocha -- src/**/*.spec.js",
-    "check-coverage": "istanbul check-coverage"
+    "check-coverage": "istanbul check-coverage coverage/coverage.json"
   },
   "dependencies": {
     "bluebird": "^3.3.5",


### PR DESCRIPTION
This fixes issues with `istanbul check-coverage` not working correctly. It checks coverage from `**/coverage*.json` (matches to `coverage/coverage.raw.json`) which is apparently generated from babelified code and not from the original source. 

`npm run coverage` output (only the global):
```
=============================== Coverage summary ===============================
Statements   : 31.58% ( 72/228 )
Branches     : 30.82% ( 45/146 )
Functions    : 23.75% ( 19/80 )
Lines        : 30.24% ( 62/205 )
================================================================================
```
`npm run check-coverage` output (with `istanbul check-coverage`, only the global):
```
ERROR: Coverage for statements (23.53%) does not meet global threshold (50%)
ERROR: Coverage for branches (20.28%) does not meet global threshold (50%)
ERROR: Coverage for lines (22.59%) does not meet global threshold (50%)
ERROR: Coverage for functions (21.55%) does not meet global threshold (50%)
```
`npm run check-coverage` output (with `istanbul check-coverage coverage/coverage.json`, only the global):
```
ERROR: Coverage for statements (31.58%) does not meet global threshold (50%)
ERROR: Coverage for branches (30.82%) does not meet global threshold (50%)
ERROR: Coverage for lines (30.24%) does not meet global threshold (50%)
ERROR: Coverage for functions (23.75%) does not meet global threshold (50%)
```

As one can see, the latter coverage matches to the `npm run coverage` output. Same applies to coverage per-file, didn't see the point in pasting a wall of text.