### PR TITLE
Fix tests failing because of importing ES6 modules from node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bundle:ios": "node ./node_modules/react-native/local-cli/cli.js bundle --platform ios --entry-file index.ios.js --bundle-output ios/PepperoniAppTemplate/main.jsbundle --dev=false --minify --verbose",
     "test": "mocha src/**/*.spec.js",
     "test:watch": "chokidar 'src/**/*.js' 'test/**/*.js' -c 'npm test'",
+    "lint": "eslint src test",
     "coverage": "rimraf coverage && istanbul cover --i=src/**/*.js _mocha -- src/**/*.spec.js",
     "check-coverage": "istanbul check-coverage"
   },
@@ -45,12 +46,12 @@
     "redux-thunk": "^2.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-eslint": "^6.0.2",
     "babel-polyfill": "^6.9.0",
     "babel-preset-react-native": "^1.7.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.9.0",
     "chai": "^3.5.0",
     "chokidar-cli": "^1.2.0",
     "enzyme": "^2.2.0",

--- a/src/components/TabBarButton.js
+++ b/src/components/TabBarButton.js
@@ -2,7 +2,7 @@ import React, {PropTypes} from 'react';
 import {
   Text,
   TouchableOpacity,
-  StyleSheet,
+  StyleSheet
 } from 'react-native';
 
 export default React.createClass({

--- a/src/modules/__specs__/AppView.spec.js
+++ b/src/modules/__specs__/AppView.spec.js
@@ -1,0 +1,39 @@
+/*eslint-disable max-nested-callbacks*/
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import Spinner from 'react-native-gifted-spinner';
+
+import AppView from '../AppView';
+
+describe('<AppView />', () => {
+  describe('isReady', () => {
+    it('should render a <Spinner /> if not ready', () => {
+      const fn = () => {};
+      const wrapper = shallow(
+        <AppView
+          isReady={false}
+          isLoggedIn={false}
+          dispatch={fn}
+        />
+      );
+
+      expect(wrapper.find(Spinner)).to.have.lengthOf(1);
+    });
+
+    it('should not render a <Spinner /> if ready', () => {
+      const fn = () => {};
+      const wrapper = shallow(
+        <AppView
+          isReady={true}
+          isLoggedIn={false}
+          dispatch={fn}
+        />
+      );
+
+      expect(wrapper.find(Spinner)).to.have.lengthOf(0);
+    });
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,6 @@
 --compilers js:babel-core/register
 --require react-native-mock/mock
 --require babel-polyfill
+--require test/setup.js
 --reporter spec
 --recursive

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,7 +1,5 @@
-global.__DEV__ = false;
-
 require('babel-register')({
-  // ignore node_modules except node_modules/react-native-vector-icons and node_modules/react-native-lock
+  // ignore node_modules except node_modules/react-native-gifted-spinner and node_modules/react-native-lock
   // because they need to be transpiled
   // syntax: /node_modules\/(?!(library1|library2))/
   ignore: /node_modules\/(?!(react-native-gifted-spinner|react-native-lock))/

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,8 @@
+global.__DEV__ = false;
+
+require('babel-register')({
+  // ignore node_modules except node_modules/react-native-vector-icons and node_modules/react-native-lock
+  // because they need to be transpiled
+  // syntax: /node_modules\/(?!(library1|library2))/
+  ignore: /node_modules\/(?!(react-native-gifted-spinner|react-native-lock))/
+});


### PR DESCRIPTION
ES6 modules needs to be transpiled for `mocha`, but by default `babel` skips `node_modules`. Added regex for skipping everything else in node_modules but `node_modules/react-native-gifted-spinner` and `node_modules/react-native-lock`. 

Also added a script for linting with `eslint` in `package.json`.

Without additional `babel-register` options: 
```
npm run test

/path/to/project/node_modules/react-native-gifted-spinner/GiftedSpinner.js:5
var {
    ^

SyntaxError: Unexpected token {
...
```

If  `global.__DEV__` is not defined:
```
ReferenceError: __DEV__ is not defined
```