### PR TITLE
Fix RESET_STATE action payload usage

### DIFF
--- a/src/redux/__specs__/reducer.spec.js
+++ b/src/redux/__specs__/reducer.spec.js
@@ -1,0 +1,22 @@
+/*eslint-disable max-nested-callbacks, no-unused-expressions*/
+
+import {describe} from 'mocha';
+import {expect} from 'chai';
+import {initialState, dispatch} from '../../../test/state';
+import * as SessionState from '../../modules/session/SessionState';
+
+describe('reducer', () => {
+  describe('mainReducer', () => {
+    describe('resets state with RESET_STATE action', () => {
+      // Use auth.isLoggedIn as an example. isReady is changed in the
+      // SessionState reducer, so the entire store state is not reset.
+      const newState = initialState.setIn(['auth', 'isLoggedIn'], true);
+      const resetStateAction = SessionState.resetSessionStateFromSnapshot(newState);
+
+      const [nextState] = dispatch(initialState, resetStateAction);
+
+      expect(initialState.getIn(['auth', 'isLoggedIn'])).to.equal(false);
+      expect(nextState.getIn(['auth', 'isLoggedIn'])).to.equal(true);
+    });
+  });
+});

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -35,7 +35,7 @@ const namespacedReducer = combineReducers(
 
 export default function mainReducer(state, action) {
   const [nextState, effects] = action.type === RESET_STATE
-    ? namespacedReducer(action.payload.state, action)
+    ? namespacedReducer(action.payload, action)
     : namespacedReducer(state || void 0, action);
 
   // enforce the state is immutable


### PR DESCRIPTION
The action creator resetSessionStateFromSnapshot in SessionState creates an action where the state is the entire payload. However, in the main reducer the state is attempted to retrieve from a nested state. I suggest the payload to be used as the state - otherwise the action creator could be changed.
