### PR TITLE
Center the activity indicator shown when app not yet ready

### DIFF
--- a/src/modules/AppView.js
+++ b/src/modules/AppView.js
@@ -31,7 +31,7 @@ const AppView = React.createClass({
   render() {
     if (!this.props.isReady) {
       return (
-        <View>
+        <View style={{flex: 1}}>
           <ActivityIndicator style={styles.centered}/>
         </View>
       );


### PR DESCRIPTION
Currently the activity indicator is wrapped by a view with no height, set `flex: 1` on container to center the activity indicator.