### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,32 @@
+language: node_js
+node_js:
+  - "6.9"
+  - "7.1"
+sudo: false
+cache:
+  directories:
+    - $HOME/.yarn-cache
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+env:
+  - NODE_ENV='test'
+install:
+  - yarn
+script:
+  - cp env.example.js env.js
+  - npm run lint
+  - npm test
+  - npm run bundle:ios
 matrix:
   include:
-    - language: node_js
-      cache: yarn
-      node_js:
-        - "6.9"
-        - "7.1"
-      sudo: false
-      env:
-        - NODE_ENV='test'
-      script:
-        - cp env.example.js env.js
-        - npm run lint
-        - npm test
-        - npm run bundle:ios
     - language: android
       os: linux
       jdk: oraclejdk7
       before_cache:
         - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
         - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-      cache:
-        directories:
-          - $HOME/.yarn-cache
-          - $HOME/.gradle/caches/
-          - $HOME/.gradle/wrapper/
       sudo: required
+      node_js: false
       before_install:
         - nvm install 7
         - node --version
@@ -32,8 +34,6 @@ matrix:
         - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
         - sudo apt-get update -qq
         - sudo apt-get install -y -qq yarn
-      install:
-        - yarn
       android:
         components:
           - build-tools-23.0.1
@@ -47,17 +47,13 @@ matrix:
     - language: objective-c
       os: osx
       osx_image: xcode8.2
-      cache:
-        directories:
-          - $HOME/.yarn-cache
+      node_js: false
       before_install:
         - nvm install 7
         - node --version
         - npm install -g yarn
         - yarn -version
-      install:
         - gem install xcpretty
-        - yarn
       xcode_project: ios/PepperoniAppTemplate.xcodeproj
       xcode_scheme: ios/PepperoniAppTemplateTests
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ cache:
     - $HOME/.gradle/wrapper/
 env:
   - NODE_ENV='test'
-install:
-  - yarn
 script:
   - cp env.example.js env.js
   - npm run lint
@@ -34,6 +32,8 @@ matrix:
         - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
         - sudo apt-get update -qq
         - sudo apt-get install -y -qq yarn
+      install:
+        - yarn
       android:
         components:
           - build-tools-23.0.1
@@ -53,7 +53,9 @@ matrix:
         - node --version
         - npm install -g yarn
         - yarn -version
+      install:
         - gem install xcpretty
+        - yarn
       xcode_project: ios/PepperoniAppTemplate.xcodeproj
       xcode_scheme: ios/PepperoniAppTemplateTests
       script:


### PR DESCRIPTION
Support multiple node.js jobs and minor optimizations

- putting node.js language outside the matrix let you run multiple versions-based jobs
- ~~and join the install (yarn) phase in one line for all the jobs~~
- I set the same cache directories for all the jobs, since it's more concise, and having the empty .gradle/* folders cached for the not-android jobs does not affect the build process -- but it's purely a choice, you can also specify the cache explicitly for every job
- it's not clear if the "NODE_ENV" variable is ever used; if so, it should be overwritten in the android/ios job, otherwise it could be dropped from the node job
