### PR TITLE
Fixed import of createLogger

### DIFF
--- a/src/redux/middleware/loggerMiddleware.js
+++ b/src/redux/middleware/loggerMiddleware.js
@@ -1,4 +1,4 @@
-import createLogger from 'redux-logger';
+import { createLogger } from 'redux-logger';
 
 // log actions in development mode
 export default createLogger({


### PR DESCRIPTION
Per (https://github.com/evgenyrodionov/redux-logger/blob/master/src/index.js) the way to import createLogger is as a destructured function -- it is not necessarily the default.