### PR TITLE
Upgrade redux-logger version, fix import

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-navigation": "^1.0.0-beta.7",
     "react-redux": "^4.4.5",
     "redux": "^3.4.0",
-    "redux-logger": "^2.6.1",
+    "redux-logger": "^3.0.6",
     "redux-loop-symbol-ponyfill": "^2.2.0",
     "redux-promise": "^0.5.3",
     "redux-thunk": "^2.0.1",

--- a/src/redux/middleware/loggerMiddleware.js
+++ b/src/redux/middleware/loggerMiddleware.js
@@ -1,4 +1,4 @@
-import createLogger from 'redux-logger';
+import { createLogger } from 'redux-logger';
 
 // log actions in development mode
 export default createLogger({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,9 +1483,9 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-diff@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.4.tgz#aac5c39952236abe5f037a2349060ba01b00ae48"
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4108,11 +4108,11 @@ redux-devtools-instrument@^1.3.3:
     lodash "^4.2.0"
     symbol-observable "^1.0.2"
 
-redux-logger@^2.6.1:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-2.8.2.tgz#52140a89afa1c1d25312cc17649c116650bf7fca"
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
   dependencies:
-    deep-diff "0.3.4"
+    deep-diff "^0.3.5"
 
 redux-loop-symbol-ponyfill@^2.2.0:
   version "2.2.2"


### PR DESCRIPTION
Rebased version of #200, also bumping redux-logger version.

Per (https://github.com/evgenyrodionov/redux-logger/blob/master/src/index.js)
the way to import createLogger is as a destructured function -- it is
not necessarily the default.