### PR TITLE
Fix react-navigator options, which broke with the release of v1.0.0-beta9

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "~15.4.2",
     "react-native": "0.42.0",
     "react-native-vector-icons": "^4.0.0",
-    "react-navigation": "^1.0.0-beta.7",
+    "react-navigation": "^1.0.0-beta.9",
     "react-redux": "^4.4.5",
     "redux": "^3.4.0",
     "redux-logger": "^2.6.1",

--- a/src/modules/colors/ColorView.js
+++ b/src/modules/colors/ColorView.js
@@ -18,17 +18,13 @@ class ColorView extends Component {
 
   static navigationOptions = {
     title: 'Colors!',
-    tabBar: () => ({
-      icon: (props) => (
+    tabBarIcon: (props) => (
         <Icon name='color-lens' size={24} color={props.tintColor} />
-      )
-    }),
+      ),
     // TODO: move this into global config?
-    header: {
-      tintColor: 'white',
-      style: {
-        backgroundColor: '#39babd'
-      }
+    headerTintColor: 'white',
+    headerStyle: {
+      backgroundColor: '#39babd'
     }
   }
 

--- a/src/modules/counter/CounterView.js
+++ b/src/modules/counter/CounterView.js
@@ -14,11 +14,9 @@ class CounterView extends Component {
 
   static navigationOptions = {
     title: 'Counter',
-    tabBar: () => ({
-      icon: (props) => (
+    tabBarIcon: (props) => (
         <Icon name='plus-one' size={24} color={props.tintColor} />
       )
-    })
   }
 
   static propTypes = {

--- a/src/modules/navigator/Navigator.js
+++ b/src/modules/navigator/Navigator.js
@@ -25,12 +25,10 @@ export const MainScreenNavigator = TabNavigator({
 
 MainScreenNavigator.navigationOptions = {
   title: 'Pepperoni App Template',
-  header: {
-    titleStyle: {color: 'white'},
-    style: {
-      backgroundColor: headerColor,
-      elevation: 0 // disable header elevation when TabNavigator visible
-    }
+  headerTitleStyle: {color: 'white'},
+  headerStyle: {
+    backgroundColor: headerColor,
+    elevation: 0 // disable header elevation when TabNavigator visible
   }
 };
 


### PR DESCRIPTION
As described here, https://github.com/react-community/react-navigation/releases/tag/v1.0.0-beta.9, react-navigator broke the style settings, which makes it unable to run. On a fresh `npm i`, this makes so that the sample app fails to run.