### PR TITLE
locate package.json file relative to the project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,4 @@ We welcome new features, but for large changes let's discuss first to make sure 
 ## Credits
 
 This project was initially motivated by [Snowflake](https://github.com/bartonhammond/snowflake), a React Native boilerplate by Barton Hammond. It shares some features and design principles for Pepperoni, but it wasn't the right fit for our needs. At this time Snowflake is more mature, so if you like Pepperoni but didn't agree with something we are doing, you should check it out to see if it's a good fit for your app.
+

--- a/README.md
+++ b/README.md
@@ -143,5 +143,3 @@ We welcome new features, but for large changes let's discuss first to make sure 
 ## Credits
 
 This project was initially motivated by [Snowflake](https://github.com/bartonhammond/snowflake), a React Native boilerplate by Barton Hammond. It shares some features and design principles for Pepperoni, but it wasn't the right fit for our needs. At this time Snowflake is more mature, so if you like Pepperoni but didn't agree with something we are doing, you should check it out to see if it's a good fit for your app.
-
-

--- a/README.md
+++ b/README.md
@@ -144,3 +144,4 @@ We welcome new features, but for large changes let's discuss first to make sure 
 
 This project was initially motivated by [Snowflake](https://github.com/bartonhammond/snowflake), a React Native boilerplate by Barton Hammond. It shares some features and design principles for Pepperoni, but it wasn't the right fit for our needs. At this time Snowflake is more mature, so if you like Pepperoni but didn't agree with something we are doing, you should check it out to see if it's a good fit for your app.
 
+

--- a/README.md
+++ b/README.md
@@ -143,4 +143,3 @@ We welcome new features, but for large changes let's discuss first to make sure 
 ## Credits
 
 This project was initially motivated by [Snowflake](https://github.com/bartonhammond/snowflake), a React Native boilerplate by Barton Hammond. It shares some features and design principles for Pepperoni, but it wasn't the right fit for our needs. At this time Snowflake is more mature, so if you like Pepperoni but didn't agree with something we are doing, you should check it out to see if it's a good fit for your app.
-

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -96,6 +96,14 @@ android {
             abiFilters "armeabi-v7a", "x86"
         }
     }
+    signingConfigs {
+        release {
+            storeFile file(System.getenv()["NC_KEYSTORE_PATH"])
+            storePassword System.getenv()["NC_KEYSTORE_PASSWORD"]
+            keyAlias System.getenv()["NC_KEY_ALIAS"]
+            keyPassword System.getenv()["NC_KEY_PASSWORD"]
+        }
+    }
     splits {
         abi {
             reset()
@@ -108,6 +116,9 @@ android {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            if (System.getenv()["CI"]) {
+                signingConfig signingConfigs.release
+            }
         }
     }
     // applicationVariants are e.g. debug, release

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ import groovy.json.JsonSlurper
 
 def getNpmVersion() {
     try {
-        def inputFile = new File("../package.json")
+        def inputFile = file("../package.json")
         def packageJson = new JsonSlurper().parseText(inputFile.text)
         return packageJson["version"]
     } catch(Exception ex) {


### PR DESCRIPTION
use fixed project directory to locate package.json file, rather than the current working directory, which can change depending on how the user runs Gradle. This is very actual for building the project via CI services.